### PR TITLE
Fix fetching an overriden package from Goopfile.lock when the original repo is gone

### DIFF
--- a/goop/vcs.go
+++ b/goop/vcs.go
@@ -49,10 +49,9 @@ func IdentifyVCS(url string) string {
 }
 
 func RepoRootForImportPathWithURLOverride(importPath string, url string) (*vcs.RepoRoot, error) {
-	repo, err := vcs.RepoRootForImportPathStatic(importPath, "ignore")
+	repo, err := vcs.RepoRootForImportPathStatic(url, "ignore")
 	if err != nil {
 		return nil, err
 	}
-	repo.Repo = url
 	return repo, nil
 }


### PR DESCRIPTION
If there's a repo that no longer exists, the
vcs.RepoRootForImportPathStatic(..) will try to ping that repo and will
fail with an error (404), therefore the whole
RepoRootForImportPathWithURLOverride(..) function will fail, failing the
whole override mechanism.

So this is a bit smarter in the sense that it passes the override url to
vcs.RepoRootForImportPathStatic(..) and then returns whatever that
function actually returns, no need to replace the url there.
